### PR TITLE
Add test to testing framework for the OIDC Authorization Code Flow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,30 +30,30 @@ jobs:
           
           for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE
           do
-            FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+              FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
-            KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
-            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "$FLOW_NAME-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
-            case "$FLOW_VARIABLE" in
-              CLIENT_CREDENTIALS)
-                curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "$FLOW_NAME", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
-                ;;
-              AUTHORIZATION_CODE)
-                curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "$FLOW_NAME", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
-                ;;
-            esac
+              KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
+              curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "'$FLOW_NAME'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
+              case "$FLOW_VARIABLE" in
+                  CLIENT_CREDENTIALS)
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
+                      ;;
+                  AUTHORIZATION_CODE)
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+                      ;;
+              esac
 
-            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
-            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
-            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
-            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="$FLOW_NAME-scope") | .id')
-            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="$FLOW_NAME-scope") | .name')
-            curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID/optional-client-scopes/$KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_ID" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
+              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
 
-            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
-            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
-            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET)" >> $GITHUB_OUTPUT
-            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME)" >> $GITHUB_OUTPUT
+              echo "$(echo $FLOW_VARIABLE)_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
+              echo "$(echo $FLOW_VARIABLE)_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
+              echo "$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET)" >> $GITHUB_OUTPUT
+              echo "$(echo $FLOW_VARIABLE)_SCOPE=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME)" >> $GITHUB_OUTPUT
           done
 
       - name: Test client credentials flow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Start & configure Keycloak and debugger
         id: configure
+        shell: bash
         run: |
           # Install testing dependencies
           npm install --prefix tests
@@ -64,6 +65,7 @@ jobs:
 
       - name: Test client credentials flow
         id: test_client_credentials
+        shell: bash
         run: |
           DISCOVERY_ENDPOINT=${{ steps.configure.outputs.CLIENT_CREDENTIALS_DISCOVERY_ENDPOINT }} \
           CLIENT_ID=${{ steps.configure.outputs.CLIENT_CREDENTIALS_CLIENT_ID }} \
@@ -73,6 +75,7 @@ jobs:
 
       - name: Test authorization code flow
         id: test_authorization_code
+        shell: bash
         run: |
           # Confidential client with PKCE
           DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
         id: configure
         shell: bash
         run: |
+          #!/bin/bash
+
           # Install testing dependencies
           npm install --prefix tests
 
@@ -63,7 +65,6 @@ jobs:
               echo "$(echo $FLOW_VARIABLE)_USER=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_USER_ID)" >> $GITHUB_OUTPUT
           done
 
-          echo $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
       - name: Test client credentials flow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,7 @@ jobs:
 
       - name: Start & configure Keycloak and debugger
         id: configure
-        shell: bash
         run: |
-          #!/bin/bash
-
           # Install testing dependencies
           npm install --prefix tests
 
@@ -29,47 +26,46 @@ jobs:
 
           # Configure Keycloak
           KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
-          curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
+          curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
           
           for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_CONFIDENTIAL AUTHORIZATION_CODE_PUBLIC
           do
-              FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+              FLOW_NAME=$(echo ${FLOW_VARIABLE} | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
               KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
-              curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "'$FLOW_NAME'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
-              case "$FLOW_VARIABLE" in
+              curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"name": "'${FLOW_NAME}'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
+              case "${FLOW_VARIABLE}" in
                   CLIENT_CREDENTIALS)
-                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
                       ;;
                   AUTHORIZATION_CODE_CONFIDENTIAL)
-                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
                       ;;
                   AUTHORIZATION_CODE_PUBLIC)
-                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
                       ;;
               esac
 
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
-              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
-              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"username": "'$FLOW_NAME'", "firstName": "'$FLOW_NAME'", "lastName": "'$FLOW_NAME'", "email": "'$FLOW_NAME'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
-              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_USER_ID); echo ${!TMP})/reset-password" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"type": "password", "value": "'$FLOW_NAME'", "temporary": false}'
+              CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].id')
+              CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].clientId')
+              CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].secret')
+              SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[] | select(.name=="'${FLOW_NAME}'-scope") | .id')
+              SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[] | select(.name=="'${FLOW_NAME}'-scope") | .name')
+              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/${CLIENT_ID}/optional-client-scopes/${SCOPE_ID}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}"
+              USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"username": "'${FLOW_NAME}'", "firstName": "'${FLOW_NAME}'", "lastName": "'${FLOW_NAME}'", "email": "'${FLOW_NAME}'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
+              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/${USER_ID}/reset-password" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"type": "password", "value": "'${FLOW_NAME}'", "temporary": false}'
 
-              echo "$(echo $FLOW_VARIABLE)_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
-              echo "$(echo $FLOW_VARIABLE)_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
-              echo "$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET)" >> $GITHUB_OUTPUT
-              echo "$(echo $FLOW_VARIABLE)_SCOPE=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME)" >> $GITHUB_OUTPUT
-              echo "$(echo $FLOW_VARIABLE)_USER=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_USER_ID)" >> $GITHUB_OUTPUT
+              echo "${FLOW_VARIABLE}_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
+              echo "${FLOW_VARIABLE}_CLIENT_ID=${CLIENT_CLIENTID}" >> $GITHUB_OUTPUT
+              echo "${FLOW_VARIABLE}_CLIENT_SECRET=${CLIENT_SECRET}" >> $GITHUB_OUTPUT
+              echo "${FLOW_VARIABLE}_SCOPE=${SCOPE_NAME}" >> $GITHUB_OUTPUT
+              echo "${FLOW_VARIABLE}_USER=${USER_ID}" >> $GITHUB_OUTPUT
           done
 
           cat $GITHUB_OUTPUT
 
       - name: Test client credentials flow
         id: test_client_credentials
-        shell: bash
         run: |
           DISCOVERY_ENDPOINT=${{ steps.configure.outputs.CLIENT_CREDENTIALS_DISCOVERY_ENDPOINT }} \
           CLIENT_ID=${{ steps.configure.outputs.CLIENT_CREDENTIALS_CLIENT_ID }} \
@@ -79,7 +75,6 @@ jobs:
 
       - name: Test authorization code flow
         id: test_authorization_code
-        shell: bash
         run: |
           # Confidential client with PKCE
           DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
           curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
           
-          for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_PRIVATE AUTHORIZATION_CODE_PUBLIC
+          for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_CONFIDENTIAL AUTHORIZATION_CODE_PUBLIC
           do
               FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
@@ -38,7 +38,7 @@ jobs:
                   CLIENT_CREDENTIALS)
                       curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
                       ;;
-                  AUTHORIZATION_CODE_PRIVATE)
+                  AUTHORIZATION_CODE_CONFIDENTIAL)
                       curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
                       ;;
                   AUTHORIZATION_CODE_PUBLIC)
@@ -59,6 +59,7 @@ jobs:
               echo "$(echo $FLOW_VARIABLE)_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
               echo "$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET)" >> $GITHUB_OUTPUT
               echo "$(echo $FLOW_VARIABLE)_SCOPE=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME)" >> $GITHUB_OUTPUT
+              echo "$(echo $FLOW_VARIABLE)_USER=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_USER_ID)" >> $GITHUB_OUTPUT
           done
 
       - name: Test client credentials flow
@@ -73,19 +74,21 @@ jobs:
       - name: Test authorization code flow
         id: test_authorization_code
         run: |
-          # Private client with PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_SCOPE }} \
+          # Confidential client with PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE }} \
+          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_USER }} \
           PKCE_ENABLED=true \
           node tests/oauth2_authorization_code.js
 
-          # Private client without PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_SCOPE }} \
+          # Confidential client without PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE }} \
+          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_USER }} \
           PKCE_ENABLED=false \
           node tests/oauth2_authorization_code.js
 
@@ -94,6 +97,7 @@ jobs:
           CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
           CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
           SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
+          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_USER }} \
           PKCE_ENABLED=true \
           node tests/oauth2_authorization_code.js
 
@@ -102,5 +106,6 @@ jobs:
           CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
           CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
           SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
+          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_USER }} \
           PKCE_ENABLED=false \
           node tests/oauth2_authorization_code.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,6 @@ jobs:
               echo "${FLOW_VARIABLE}_USER=${USER_ID}" >> $GITHUB_OUTPUT
           done
 
-          cat $GITHUB_OUTPUT
-
       - name: Test client credentials flow
         id: test_client_credentials
         run: |
@@ -76,38 +74,23 @@ jobs:
       - name: Test authorization code flow
         id: test_authorization_code
         run: |
-          # Confidential client with PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE }} \
-          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_USER }} \
-          PKCE_ENABLED=true \
-          node tests/oauth2_authorization_code.js
+          for PKCE_ENABLED in true false
+          do
+              # Confidential client
+              DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \
+              CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID }} \
+              CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET }} \
+              SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE }} \
+              USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_USER }} \
+              PKCE_ENABLED=${PKCE_ENABLED} \
+              node tests/oauth2_authorization_code.js
 
-          # Confidential client without PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE }} \
-          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_CONFIDENTIAL_USER }} \
-          PKCE_ENABLED=false \
-          node tests/oauth2_authorization_code.js
-
-          # Public client with PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
-          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_USER }} \
-          PKCE_ENABLED=true \
-          node tests/oauth2_authorization_code.js
-
-          # Public client without PKCE
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
-          USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_USER }} \
-          PKCE_ENABLED=false \
-          node tests/oauth2_authorization_code.js
+              # Public client
+              DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT }} \
+              CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
+              CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
+              SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
+              USER=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_USER }} \
+              PKCE_ENABLED=${PKCE_ENABLED} \
+              node tests/oauth2_authorization_code.js
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,9 @@ jobs:
               echo "$(echo $FLOW_VARIABLE)_USER=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_USER_ID)" >> $GITHUB_OUTPUT
           done
 
+          echo $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+
       - name: Test client credentials flow
         id: test_client_credentials
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,37 +17,59 @@ jobs:
       - name: Start & configure Keycloak and debugger
         id: configure
         run: |
+          # Install testing dependencies
+          npm install --prefix tests
+
           # Start Docker containers
           CONFIG_FILE=./env/local.js docker compose -f docker-compose-with-keycloak.yml up -d --build
           sleep 30
 
-          # Configure client credentials flow
+          # Configure Keycloak
           KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
           curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
-          curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "client-credentials-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
-          curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "client-credentials", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
-          KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
-          KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
-          KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
-          KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="client-credentials-scope") | .id')
-          KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="client-credentials-scope") | .name')
-          curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_ID/optional-client-scopes/$KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_ID" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+          
+          for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE
+          do
+            FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
-          # Share variables to next steps
-          echo "CLIENT_CREDENTIALS_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
-          echo "CLIENT_CREDENTIALS_CLIENT_ID=$(echo $KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
-          echo "CLIENT_CREDENTIALS_CLIENT_SECRET=$(echo $KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_SECRET)" >> $GITHUB_OUTPUT
-          echo "CLIENT_CREDENTIALS_SCOPE=$(echo $KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME)" >> $GITHUB_OUTPUT
+            KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "$FLOW_NAME-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
+            case "$FLOW_VARIABLE" in
+              CLIENT_CREDENTIALS)
+                curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "$FLOW_NAME", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
+                ;;
+              AUTHORIZATION_CODE)
+                curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "$FLOW_NAME", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+                ;;
+            esac
+
+            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
+            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
+            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
+            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="$FLOW_NAME-scope") | .id')
+            KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="$FLOW_NAME-scope") | .name')
+            curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID/optional-client-scopes/$KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_ID" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+
+            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
+            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
+            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_SECRET)" >> $GITHUB_OUTPUT
+            echo "$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_SCOPE_NAME)" >> $GITHUB_OUTPUT
+          done
 
       - name: Test client credentials flow
         id: test_client_credentials
         run: |
-          # Install dependencies
-          cd tests && npm install
-
-          # Test client credentials flow
           DISCOVERY_ENDPOINT=${{ steps.configure.outputs.CLIENT_CREDENTIALS_DISCOVERY_ENDPOINT }} \
           CLIENT_ID=${{ steps.configure.outputs.CLIENT_CREDENTIALS_CLIENT_ID }} \
           CLIENT_SECRET=${{ steps.configure.outputs.CLIENT_CREDENTIALS_CLIENT_SECRET }} \
           SCOPE=${{ steps.configure.outputs.CLIENT_CREDENTIALS_SCOPE }} \
-          node oauth2_client_credentials.js
+          node tests/oauth2_client_credentials.js
+
+      - name: Test authorization code flow
+        id: test_authorization_code
+        run: |
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_SCOPE }} \
+          node tests/oauth2_authorization_code.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
           curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
           
-          for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE
+          for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_PRIVATE AUTHORIZATION_CODE_PUBLIC
           do
               FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
@@ -38,8 +38,11 @@ jobs:
                   CLIENT_CREDENTIALS)
                       curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
                       ;;
-                  AUTHORIZATION_CODE)
+                  AUTHORIZATION_CODE_PRIVATE)
                       curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+                      ;;
+                  AUTHORIZATION_CODE_PUBLIC)
+                      curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
                       ;;
               esac
 
@@ -49,6 +52,8 @@ jobs:
               declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
               declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
               curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+              declare KEYCLOAK_$(echo $FLOW_VARIABLE)_USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"username": "'$FLOW_NAME'", "firstName": "'$FLOW_NAME'", "lastName": "'$FLOW_NAME'", "email": "'$FLOW_NAME'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
+              curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_USER_ID); echo ${!TMP})/reset-password" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"type": "password", "value": "'$FLOW_NAME'", "temporary": false}'
 
               echo "$(echo $FLOW_VARIABLE)_DISCOVERY_ENDPOINT=http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" >> $GITHUB_OUTPUT
               echo "$(echo $FLOW_VARIABLE)_CLIENT_ID=$(echo $KEYCLOAK_$(TMP=$(echo $FLOW_VARIABLE);echo ${!TMP})_CLIENT_CLIENTID)" >> $GITHUB_OUTPUT
@@ -68,8 +73,34 @@ jobs:
       - name: Test authorization code flow
         id: test_authorization_code
         run: |
-          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_DISCOVERY_ENDPOINT }} \
-          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_CLIENT_ID }} \
-          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_CLIENT_SECRET }} \
-          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_SCOPE }} \
+          # Private client with PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_SCOPE }} \
+          PKCE_ENABLED=true \
+          node tests/oauth2_authorization_code.js
+
+          # Private client without PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PRIVATE_SCOPE }} \
+          PKCE_ENABLED=false \
+          node tests/oauth2_authorization_code.js
+
+          # Public client with PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
+          PKCE_ENABLED=true \
+          node tests/oauth2_authorization_code.js
+
+          # Public client without PKCE
+          DISCOVERY_ENDPOINT=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT }} \
+          CLIENT_ID=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_ID }} \
+          CLIENT_SECRET=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET }} \
+          SCOPE=${{ steps.configure.outputs.AUTHORIZATION_CODE_PUBLIC_SCOPE }} \
+          PKCE_ENABLED=false \
           node tests/oauth2_authorization_code.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 api/node_modules
 client/node_modules
 node_modules
+.idea

--- a/api/server.js
+++ b/api/server.js
@@ -198,12 +198,6 @@ app.post('/token', (req, res) => {
                       "&";
     });
 
-    if (!tokenEndpoint.includes(`${HOST}:${PORT}`)) {
-      log.error('Invalid token endpoint: ' + tokenEndpoint);
-      res.status(400)
-      res.json({ error: 'Invalid token endpoint' });
-    }
-
     var headers = {
       'content-type' : 'application/x-www-form-urlencoded'
     };

--- a/api/server.js
+++ b/api/server.js
@@ -11,11 +11,6 @@ const bunyan = require("bunyan");
 const axios = require('axios');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const appconfig = require(process.env.CONFIG_FILE);
-
-if (!appconfig) {
-  log.debug('Failed to load appconfig.');
-}
 
 // Constants
 const PORT = process.env.PORT || 4000;
@@ -203,7 +198,7 @@ app.post('/token', (req, res) => {
                       "&";
     });
 
-    if (tokenEndpoint != appconfig.apiUrl) {
+    if (!tokenEndpoint.includes(`${HOST}:${PORT}`)) {
       log.error('Invalid token endpoint: ' + tokenEndpoint);
       res.status(400)
       res.json({ error: 'Invalid token endpoint' });

--- a/api/server.js
+++ b/api/server.js
@@ -11,6 +11,11 @@ const bunyan = require("bunyan");
 const axios = require('axios');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const appconfig = require(process.env.CONFIG_FILE);
+
+if (!appconfig) {
+  log.debug('Failed to load appconfig.');
+}
 
 // Constants
 const PORT = process.env.PORT || 4000;
@@ -197,6 +202,13 @@ app.post('/token', (req, res) => {
                       parameterObject[key] +
                       "&";
     });
+
+    if (tokenEndpoint != appconfig.apiUrl) {
+      log.error('Invalid token endpoint: ' + tokenEndpoint);
+      res.status(400)
+      res.json({ error: 'Invalid token endpoint' });
+    }
+
     var headers = {
       'content-type' : 'application/x-www-form-urlencoded'
     };
@@ -278,4 +290,3 @@ let options = {
 expressSwagger(options)
 app.listen(PORT, HOST);
 log.info(`Running on http://${HOST}:${PORT}`);
-

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,76 +9,67 @@ sleep 30
 
 # Configure Keycloak
 KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
-curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
+curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
 
 for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_CONFIDENTIAL AUTHORIZATION_CODE_PUBLIC
 do
-    FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    FLOW_NAME=$(echo ${FLOW_VARIABLE} | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
     KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
-    curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "'$FLOW_NAME'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
-    case "$FLOW_VARIABLE" in
+    curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"name": "'${FLOW_NAME}'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
+    case "${FLOW_VARIABLE}" in
         CLIENT_CREDENTIALS)
-            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
             ;;
         AUTHORIZATION_CODE_CONFIDENTIAL)
-            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
             ;;
         AUTHORIZATION_CODE_PUBLIC)
-            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"clientId": "'${FLOW_NAME}'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
             ;;
     esac
 
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
-    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
-    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"username": "'$FLOW_NAME'", "firstName": "'$FLOW_NAME'", "lastName": "'$FLOW_NAME'", "email": "'$FLOW_NAME'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
-    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_USER_ID); echo ${!TMP})/reset-password" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"type": "password", "value": "'$FLOW_NAME'", "temporary": false}'
+    CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].id')
+    CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].clientId')
+    CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=${FLOW_NAME}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[0].secret')
+    SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[] | select(.name=="'${FLOW_NAME}'-scope") | .id')
+    SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" | jq -r '.[] | select(.name=="'${FLOW_NAME}'-scope") | .name')
+    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/${CLIENT_ID}/optional-client-scopes/${SCOPE_ID}" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}"
+    USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"username": "'${FLOW_NAME}'", "firstName": "'${FLOW_NAME}'", "lastName": "'${FLOW_NAME}'", "email": "'${FLOW_NAME}'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
+    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/${USER_ID}/reset-password" -H "Authorization: Bearer ${KEYCLOAK_ACCESS_TOKEN}" -H "Content-Type: application/json" -d '{"type": "password", "value": "'${FLOW_NAME}'", "temporary": false}'
+
+    declare ${FLOW_VARIABLE}_DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration"
+    declare ${FLOW_VARIABLE}_CLIENT_ID="${CLIENT_CLIENTID}"
+    declare ${FLOW_VARIABLE}_CLIENT_SECRET="${CLIENT_SECRET}"
+    declare ${FLOW_VARIABLE}_SCOPE="${SCOPE_NAME}"
+    declare ${FLOW_VARIABLE}_USER="${USER_ID}"
 done
 
 # Test client credentials flow
-DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME \
+DISCOVERY_ENDPOINT=${CLIENT_CREDENTIALS_DISCOVERY_ENDPOINT} \
+CLIENT_ID=${CLIENT_CREDENTIALS_CLIENT_ID} \
+CLIENT_SECRET=${CLIENT_CREDENTIALS_CLIENT_SECRET} \
+SCOPE=${CLIENT_CREDENTIALS_SCOPE} \
 node tests/oauth2_client_credentials.js
 
 # Test authorization code flow
-## Confidential client with PKCE
-DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE_NAME \
-USER=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_USER_ID \
-PKCE_ENABLED=true \
-node tests/oauth2_authorization_code.js
+for PKCE_ENABLED in true false
+do
+    # Confidential client
+    DISCOVERY_ENDPOINT=${AUTHORIZATION_CODE_CONFIDENTIAL_DISCOVERY_ENDPOINT} \
+    CLIENT_ID=${AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_ID} \
+    CLIENT_SECRET=${AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET} \
+    SCOPE=${AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE} \
+    USER=${AUTHORIZATION_CODE_CONFIDENTIAL_USER} \
+    PKCE_ENABLED=${PKCE_ENABLED} \
+    node tests/oauth2_authorization_code.js
 
-## Confidential client without PKCE
-DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_SCOPE_NAME \
-USER=$KEYCLOAK_AUTHORIZATION_CODE_CONFIDENTIAL_USER_ID \
-PKCE_ENABLED=false \
-node tests/oauth2_authorization_code.js
-
-## Public client with PKCE
-DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_SCOPE_NAME \
-USER=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_USER_ID \
-PKCE_ENABLED=true \
-node tests/oauth2_authorization_code.js
-
-## Public client without PKCE
-DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_SCOPE_NAME \
-USER=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_USER_ID \
-PKCE_ENABLED=false \
-node tests/oauth2_authorization_code.js
+    # Public client
+    DISCOVERY_ENDPOINT=${AUTHORIZATION_CODE_PUBLIC_DISCOVERY_ENDPOINT} \
+    CLIENT_ID=${AUTHORIZATION_CODE_PUBLIC_CLIENT_ID} \
+    CLIENT_SECRET=${AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET} \
+    SCOPE=${AUTHORIZATION_CODE_PUBLIC_SCOPE} \
+    USER=${AUTHORIZATION_CODE_PUBLIC_USER} \
+    PKCE_ENABLED=${PKCE_ENABLED} \
+    node tests/oauth2_authorization_code.js
+done

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ sleep 30
 KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
 curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
 
-for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE
+for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE_PRIVATE AUTHORIZATION_CODE_PUBLIC
 do
     FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 
@@ -21,8 +21,11 @@ do
         CLIENT_CREDENTIALS)
             curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
             ;;
-        AUTHORIZATION_CODE)
+        AUTHORIZATION_CODE_PRIVATE)
             curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+            ;;
+        AUTHORIZATION_CODE_PUBLIC)
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": true, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": null, "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
             ;;
     esac
 
@@ -32,6 +35,8 @@ do
     declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
     declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
     curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_USER_ID=$(curl -X POST "http://localhost:8080/admin/realms/debugger-testing/users" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"username": "'$FLOW_NAME'", "firstName": "'$FLOW_NAME'", "lastName": "'$FLOW_NAME'", "email": "'$FLOW_NAME'@iyasec.io", "enabled": true, "emailVerified": true}' -i | grep Location | rev | cut -d '/' -f 1 | rev | tr -d ' \n\r')
+    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/users/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_USER_ID); echo ${!TMP})/reset-password" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"type": "password", "value": "'$FLOW_NAME'", "temporary": false}'
 done
 
 # Test client credentials flow
@@ -42,8 +47,34 @@ SCOPE=$KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME \
 node tests/oauth2_client_credentials.js
 
 # Test authorization code flow
+## Private client with PKCE
 DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
-CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_CLIENT_CLIENTID \
-CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_CLIENT_SECRET \
-SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_SCOPE_NAME \
+CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_CLIENT_CLIENTID \
+CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET \
+SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_SCOPE_NAME \
+PKCE_ENABLED=true \
+node tests/oauth2_authorization_code.js
+
+## Private client without PKCE
+DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
+CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_CLIENT_CLIENTID \
+CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_CLIENT_SECRET \
+SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PRIVATE_SCOPE_NAME \
+PKCE_ENABLED=false \
+node tests/oauth2_authorization_code.js
+
+## Public client with PKCE
+DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
+CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_CLIENTID \
+CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET \
+SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_SCOPE_NAME \
+PKCE_ENABLED=true \
+node tests/oauth2_authorization_code.js
+
+## Public client without PKCE
+DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
+CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_CLIENTID \
+CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_CLIENT_SECRET \
+SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_PUBLIC_SCOPE_NAME \
+PKCE_ENABLED=false \
 node tests/oauth2_authorization_code.js

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,27 +1,49 @@
 #!/bin/bash
 
+# Install testing dependencies
+npm install --prefix tests
+
 # Start Docker containers
 CONFIG_FILE=./env/local.js docker compose -f docker-compose-with-keycloak.yml up -d --build
 sleep 30
 
-# Configure client credentials flow
+# Configure Keycloak
 KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
 curl -X POST "http://localhost:8080/admin/realms" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"realm": "debugger-testing", "enabled": true}'
-curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "client-credentials-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
-curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "client-credentials", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
-KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
-KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
-KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=client-credentials" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
-KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="client-credentials-scope") | .id')
-KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="client-credentials-scope") | .name')
-curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_ID/optional-client-scopes/$KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_ID" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
 
-# Install dependencies
-cd tests && npm install
+for FLOW_VARIABLE in CLIENT_CREDENTIALS AUTHORIZATION_CODE
+do
+    FLOW_NAME=$(echo $FLOW_VARIABLE | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+
+    KEYCLOAK_ACCESS_TOKEN=$(curl -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=admin-cli" -d "username=keycloak" -d "password=keycloak" -d "grant_type=password" | jq -r '.access_token')
+    curl -X POST "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"name": "'$FLOW_NAME'-scope", "protocol": "openid-connect", "attributes": {"display.on.consent.screen": "false", "include.in.token.scope": "true"}}'
+    case "$FLOW_VARIABLE" in
+        CLIENT_CREDENTIALS)
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": true, "authorizationServicesEnabled": false, "standardFlowEnabled": false, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret"}'
+            ;;
+        AUTHORIZATION_CODE)
+            curl -X POST "http://localhost:8080/admin/realms/debugger-testing/clients" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"clientId": "'$FLOW_NAME'", "protocol": "openid-connect", "publicClient": false, "serviceAccountsEnabled": false, "authorizationServicesEnabled": false, "standardFlowEnabled": true, "directAccessGrantsEnabled": false, "clientAuthenticatorType": "client-secret", "frontchannelLogout": true, "redirectUris": ["http://localhost:3000/callback"], "webOrigins": ["/*", "http://localhost:3000/*"], "attributes": {"frontchannel.logout.url": "http://localhost:3000/logout"}}'
+            ;;
+    esac
+
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].id')
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_CLIENTID=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].clientId')
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_CLIENT_SECRET=$(curl "http://localhost:8080/admin/realms/debugger-testing/clients?clientId=$FLOW_NAME" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[0].secret')
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_ID=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .id')
+    declare KEYCLOAK_$(echo $FLOW_VARIABLE)_SCOPE_NAME=$(curl "http://localhost:8080/admin/realms/debugger-testing/client-scopes" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN" | jq -r '.[] | select(.name=="'$FLOW_NAME'-scope") | .name')
+    curl -X PUT "http://localhost:8080/admin/realms/debugger-testing/clients/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_CLIENT_ID); echo ${!TMP})/optional-client-scopes/$(TMP=$(echo KEYCLOAK_${FLOW_VARIABLE}_SCOPE_ID); echo ${!TMP})" -H "Authorization: Bearer $KEYCLOAK_ACCESS_TOKEN"
+done
 
 # Test client credentials flow
 DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
 CLIENT_ID=$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_CLIENTID \
 CLIENT_SECRET=$KEYCLOAK_CLIENT_CREDENTIALS_CLIENT_SECRET \
 SCOPE=$KEYCLOAK_CLIENT_CREDENTIALS_SCOPE_NAME \
-node oauth2_client_credentials.js
+node tests/oauth2_client_credentials.js
+
+# Test authorization code flow
+DISCOVERY_ENDPOINT="http://localhost:8080/realms/debugger-testing/.well-known/openid-configuration" \
+CLIENT_ID=$KEYCLOAK_AUTHORIZATION_CODE_CLIENT_CLIENTID \
+CLIENT_SECRET=$KEYCLOAK_AUTHORIZATION_CODE_CLIENT_SECRET \
+SCOPE=$KEYCLOAK_AUTHORIZATION_CODE_SCOPE_NAME \
+node tests/oauth2_authorization_code.js

--- a/tests/oauth2_authorization_code.js
+++ b/tests/oauth2_authorization_code.js
@@ -1,0 +1,112 @@
+const { Builder, By, until } = require("selenium-webdriver");
+const { Select } = require('selenium-webdriver/lib/select');
+const chrome = require("selenium-webdriver/chrome");
+const jwt = require("jsonwebtoken");
+const assert = require("assert");
+
+async function populateMetadata(driver, discovery_endpoint) {
+  oidc_discovery_endpoint = By.id("oidc_discovery_endpoint");
+  btn_oidc_discovery_endpoint = By.className("btn_oidc_discovery_endpoint");
+  btn_oidc_populate_meta_data = By.className("btn_oidc_populate_meta_data");
+
+  // Wait until page is loaded
+  await driver.wait(until.elementLocated(oidc_discovery_endpoint), 10000);
+  await driver.wait(until.elementIsVisible(driver.findElement(oidc_discovery_endpoint)), 10000);
+
+  // Enter discovery endpoint
+  await driver.findElement(oidc_discovery_endpoint).clear();
+  await driver.findElement(oidc_discovery_endpoint).sendKeys(discovery_endpoint); 
+  await driver.findElement(btn_oidc_discovery_endpoint).click();
+
+  // Populate metadata
+  await driver.wait(until.elementLocated(btn_oidc_populate_meta_data), 10000);
+  await driver.wait(until.elementIsVisible(driver.findElement(btn_oidc_populate_meta_data)), 10000);
+  await driver.executeScript("arguments[0].scrollIntoView({ behavior: 'smooth', block: 'center' });", await driver.findElement(btn_oidc_populate_meta_data));
+  await driver.findElement(btn_oidc_populate_meta_data).click();
+}
+
+async function getAccessToken(driver, client_id, client_secret, scope) {
+  authorization_grant_type = By.id("authorization_grant_type");
+  token_client_id = By.id("token_client_id");
+  token_client_secret = By.id("token_client_secret");
+  token_scope = By.id("token_scope");
+  btn1 = By.className("btn1");
+  token_access_token = By.id("token_access_token");
+  display_token_error_form_textarea1 = By.id("display_token_error_form_textarea1");
+
+  // Select client credential login type
+  await new Select(await driver.findElement(authorization_grant_type)).selectByVisibleText('OAuth2 Client Credential');
+  await driver.wait(until.elementLocated(token_client_id), 10000);
+  await driver.wait(until.elementIsVisible(driver.findElement(token_client_id)), 10000);
+
+  // Submit credentials
+  await driver.findElement(token_client_id).clear();
+  await driver.findElement(token_client_id).sendKeys(client_id);
+  await driver.findElement(token_client_secret).clear();
+  await driver.findElement(token_client_secret).sendKeys(client_secret);
+  await driver.findElement(token_scope).clear();
+  await driver.findElement(token_scope).sendKeys(scope);
+  await driver.findElement(btn1).click();
+
+  // Get access token result
+  async function waitForVisibility(element) {
+    await driver.wait(until.elementLocated(element), 10000);
+    await driver.wait(until.elementIsVisible(driver.findElement(element)), 10000);
+    return element;
+  }
+
+  let visibleAccessTokenElement = await Promise.any([
+    waitForVisibility(token_access_token),
+    waitForVisibility(display_token_error_form_textarea1)
+  ]);
+
+  return await driver.findElement(visibleAccessTokenElement).getAttribute("value");
+}
+
+async function verifyAccessToken(access_token, client_id, scope) {
+  async function compareScopes(scope1, scope2) {
+    scope1 = scope1.split(" ");
+    scope2 = scope2.split(" ");
+
+    return scope2.every(element => scope1.includes(element));
+  }
+
+  let decoded_access_token = jwt.decode(access_token, { complete: true });
+  let response_text = access_token.match(/responseText: (.*)/);
+
+  assert.notStrictEqual(decoded_access_token, null, "Cannot decode access token. Request result: " + (response_text ? response_text[1] : "no response text"));
+  assert.strictEqual(decoded_access_token.payload.client_id, client_id, "Access token client ID does not match client ID.");
+  assert.strictEqual(await compareScopes(decoded_access_token.payload.scope, scope), true, "Access token scope does not match scope.");
+}
+
+async function test() {
+  const options = new chrome.Options();
+  options.addArguments("--headless");
+  options.addArguments("--no-sandbox");
+  const driver = await new Builder().forBrowser("chrome").setChromeOptions(options).build();
+
+  try {
+    const discovery_endpoint = process.env.DISCOVERY_ENDPOINT;
+    const client_id = process.env.CLIENT_ID;
+    const client_secret = process.env.CLIENT_SECRET;
+    const scope = process.env.SCOPE;
+
+    assert(discovery_endpoint, "DISCOVERY_ENDPOINT environment variable is not set.");
+    assert(client_id, "CLIENT_ID environment variable is not set.");
+    assert(client_secret, "CLIENT_SECRET environment variable is not set.");
+    assert(scope, "SCOPE environment variable is not set.");
+
+    await driver.get("http://localhost:3000");
+    await populateMetadata(driver, discovery_endpoint);
+    let access_token = await getAccessToken(driver, client_id, client_secret, scope);
+    await verifyAccessToken(access_token, client_id, scope);
+    console.log("Test completed successfully.")
+  } catch (error) {
+    console.log(error.message);
+    process.exit(1);
+  } finally {
+    await driver.quit();
+  }
+}
+
+test();


### PR DESCRIPTION
- Use the keycloak IdP already embedded in the pipeline to configure a client for this.
- There are a couple of variations that need to be tested including public client vs confidential client, with PKCE vs no PKCE.
- Those four combinations will be the tests that need to be added.
- Add a scope to a new client configuration that can be checked for validation.