### PR TITLE
Potential fix for code scanning alert no. 55: Type confusion through parameter tampering

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -887,6 +887,9 @@ function handleSamlAcs(req, res) {
   try {
     var samlResponse = (req.body && req.body.SAMLResponse) || req.query.SAMLResponse;
     var relayState = (req.body && req.body.RelayState) || req.query.RelayState || '';
+    if (typeof relayState !== 'string') {
+      return res.status(STATUS_400).send('ACS: invalid RelayState.');
+    }
     var artifact = (req.body && req.body.SAMLart) || req.query.SAMLart;
 
     if (samlResponse) {


### PR DESCRIPTION
Potential fix for [https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/55](https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/55)

The fix is to enforce that `RelayState` is a string before any string-method checks or downstream use. In this snippet, the safest minimal fix is to normalize/validate in `handleSamlAcs` right after extracting `relayState`: if it is not a string, reject the request with `400`. This preserves existing functionality for valid requests and prevents array/object tampering from reaching `resolveArtifact`.

Best single change:
- **File:** `api/server.js`
- **Region:** inside `handleSamlAcs`, immediately after line 889 (where `relayState` is assigned), before it is passed to `stashSamlResponse` / `resolveArtifact`.
- Add a runtime type guard:
  - `if (typeof relayState !== 'string') { return res.status(STATUS_400).send('ACS: invalid RelayState.'); }`

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
