### PR TITLE
Potential fix for code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/client/server.js
+++ b/client/server.js
@@ -22,6 +22,7 @@ const HOST = appconfig.hostname || '0.0.0.0';
 
 // App
 const app = express();
+const PUBLIC_ROOT = path.resolve(__dirname, 'public');
 
 // Code-coverage collection endpoint (opt-in via COVERAGE=true). The
 // Istanbul-instrumented browser bundles POST their window.__coverage__ here on
@@ -55,11 +56,18 @@ app.use(function(req, res, next) {
   // (header/footer) are resolved; otherwise express.static would serve it raw.
   var reqPath = (req.path === '/') ? '/index.html' : req.path;
   if (!reqPath.endsWith('.html')) { return next(); }
-  const filePath = path.join(__dirname, 'public', reqPath);
+  const filePath = path.resolve(PUBLIC_ROOT, '.' + reqPath);
+  if (!(filePath === PUBLIC_ROOT || filePath.startsWith(PUBLIC_ROOT + path.sep))) { return next(); }
   fs.readFile(filePath, 'utf8', function(err, content) {
     if (err) { return next(); }
     var processed = content.replace(/<!--#include file="([^"]+)"-->/g, function(match, file) {
-      try { return fs.readFileSync(path.join(__dirname, 'public', file), 'utf8'); }
+      try {
+        const includePath = path.resolve(PUBLIC_ROOT, file);
+        if (!(includePath === PUBLIC_ROOT || includePath.startsWith(PUBLIC_ROOT + path.sep))) {
+          throw new Error('Path traversal attempt');
+        }
+        return fs.readFileSync(includePath, 'utf8');
+      }
       catch(e) { log.error('SSI include failed: ' + file + ' - ' + e); return ''; }
     });
     // Stamp the copyright year ({{YEAR}} in the footer partial / error pages).


### PR DESCRIPTION
Potential fix for [https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/42](https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/42)

Use a safe-root validation pattern:
1. Define the static root once: `const PUBLIC_ROOT = path.resolve(__dirname, 'public');`
2. For request HTML file reads, resolve the user path against that root and verify the resolved path begins with the root plus separator (or equals root).
3. Apply the same protection for SSI include files, since include names come from file content and should also be constrained to `public`.
4. If validation fails, return/skip (`next()` for main page read, empty string for SSI include).

In `client/server.js`, update the middleware around lines 53–77:
- add `PUBLIC_ROOT` constant near app initialization,
- replace `path.join(__dirname, 'public', reqPath)` with `path.resolve(PUBLIC_ROOT, '.' + reqPath)` and enforce containment,
- replace SSI `path.join(__dirname, 'public', file)` with a validated resolved include path.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
