### PR TITLE
Potential fix for code scanning alert no. 144: Information exposure through a stack trace

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -637,7 +637,7 @@ app.get('/claimdescription', function(req, res) {
     log.error("An error occurred while retrieving the claim description XML: " + e.stack);
     res.status(STATUS_500)
        .render('error', {
-         error: e });
+         error: 'An unexpected error occurred.' });
   }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/144](https://github.com/rcbj/oauth2-oidc-debugger/security/code-scanning/144)

General fix: never return raw exception objects or stack traces in HTTP responses. Log full details server-side, and return a generic error payload/view model to clients.

Best minimal fix here: keep the existing server-side logging of `e.stack`, but replace the rendered `error` object with a safe generic object/string so templates cannot expose internals.

Edit only `api/server.js`, in the `/claimdescription` `catch(e)` block (lines 637–640 region):
- Keep `log.error(...)` as-is (or equivalent server logging).
- Change `.render('error', { error: e })` to `.render('error', { error: 'An unexpected error occurred.' })`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
